### PR TITLE
Enable support for fzf-tmux

### DIFF
--- a/zsh/fzf-zsh-completion.sh
+++ b/zsh/fzf-zsh-completion.sh
@@ -136,7 +136,7 @@ _fzf_completion_selector() {
 
     tput cud1 >/dev/tty # fzf clears the line on exit so move down one
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" \
-        fzf --ansi --prompt "> $PREFIX" -d "$_FZF_COMPLETION_SEP" --with-nth 3..5 --nth "$field" \
+        $(__fzfcmd) --ansi --prompt "> $PREFIX" -d "$_FZF_COMPLETION_SEP" --with-nth 3..5 --nth "$field" \
         < <(printf %s\\n "${lines[@]}"; cat)
     code="$?"
     tput cuu1 >/dev/tty


### PR DESCRIPTION
This is compatible without tmux, too. It respects `FZF_TMUX`.

Test with that env var set to both `0` and `1` and it behaves as expeccted.

Closes #9 