### PR TITLE
Hide example screencast in collapsible block

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ This is distinct from
 in that it works _with_ the existing completion mechanisms
 rather than [creating a new mechanism](https://github.com/junegunn/fzf/wiki/Examples-(completion)).
 
+## Example
+<details><summary>Click here to show screencast</summary>
+
 ![Example](./example.svg)
+</details>
 
 ## Installation
 


### PR DESCRIPTION
The embedded example.svg creates some INCREDIBLY bad lag in Chrome;
enough that simply having the README open causes the tab to be nearly
unusable.

It doesn't even load in Safari. Firefox seems fine for some reason.

The lag in Chrome only exists when the SVG is on-screen, not when it
loads. This is obviously a stopgap; I would consider moving that example to
a screencast host and embedding that instead.