### PR TITLE
Bash completion: clear "loading matches..." string when done

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -105,7 +105,7 @@ _fzf_bash_completion_parse_line() {
 }
 
 fzf_bash_completion() {
-    printf 'Loading matches ...\r'
+    printf '%s\r' "${FZF_BASH_WIPSTR:-"Loading matches ..."}"
 
     local COMP_WORDS COMP_CWORD COMP_POINT COMP_LINE
     local line="${READLINE_LINE:0:READLINE_POINT}"
@@ -141,6 +141,7 @@ fzf_bash_completion() {
     fi
 
     printf '\r'
+    command tput el 2>/dev/null || echo -ne "\033[K"
 }
 
 _fzf_bash_completion_selector() {

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -105,7 +105,7 @@ _fzf_bash_completion_parse_line() {
 }
 
 fzf_bash_completion() {
-    printf '%s\r' "${FZF_BASH_WIPSTR:-"Loading matches ..."}"
+    printf '%s\r' "${FZF_BASH_WIPSTR-"Loading matches ..."}"
 
     local COMP_WORDS COMP_CWORD COMP_POINT COMP_LINE
     local line="${READLINE_LINE:0:READLINE_POINT}"


### PR DESCRIPTION
When completion is done, clear the current line before bash redraws it, so that it doesn't leave random dots at the end of the line.
Also, customization of the "loading" text is possible by setting the `FZF_BASH_WIPSTR` variable.

This does not completely solve issue #15, as there is no way to prevent the line from being cleared when bash runs code bound to a key sequence (see bash's code, `bashline.c` file, `bash_execute_unix_command` function), but should at least lessen the problem.