### PR TITLE
Bash completion - Fixes to input line splitting

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -8,7 +8,14 @@ _fzf_bash_completion_awk_escape() {
 _fzf_bash_completion_egrep="$(command -v rg || command -v ag || echo egrep)"
 
 _fzf_bash_completion_shell_split() {
-    "$_fzf_bash_completion_egrep" -o -e ';|\(|\)|\{|\}' -e "(\\\\.|[^\"'[:space:];(){}])+" -e "\\\$'(\\\\.|[^'])*('|$)" -e "'[^']*('|$)" -e "\"(\\\\.|\\\$(\$|[^(])|[^\"\$])*(\"|\$)" -e '".*' -e .
+    "$_fzf_bash_completion_egrep" -o \
+        -e ';|\(|\)|\{|\}|&|\|' \
+        -e '\|+|&+' \
+        -e "(\\\\.|[^\"'[:space:];(){}&\\|])+" \
+        -e "\\\$'(\\\\.|[^'])*('|$)" \
+        -e "'[^']*('|$)" \
+        -e '"(\\.|\$($|[^(])|[^"$])*("|$)' \
+        -e '".*' -e .
 }
 
 _fzf_bash_completion_unbuffered_awk() {
@@ -98,9 +105,17 @@ _fzf_bash_completion_parse_line() {
     _fzf_bash_completion_shell_split \
         | _fzf_bash_completion_parse_dq \
         | _fzf_bash_completion_flatten_subshells \
-        | tr \\n \\0 | sed -r 's/\x00\s*\x00/\n/g; s/\x00(\S|$)/\1/g; s/\x00(\s*)$/\n\1/' \
-        | tr \\n \\0 | sed -r "s/^(.*\\x00)?(\\[\\[|case|do|done|elif|else|esac|fi|for|function|if|in|select|then|time|until|while|;|&&|\\|[|&]?)\\x00//" \
-        | sed -r 's/^(\s*\x00|\w+=[^\x00]*\x00)*//' \
+        | tr \\n \\0 \
+        | sed -r "$(cat <<'EOF'
+s/\x00\s*\x00/\n/g;
+s/\x00(\s*)$/\n\1/;
+s/([^&\n\x00])&([^&\n\x00])/\1\n\&\n\2/g;
+s/([\n\x00\z])([<>]+)([^\n\x00])/\1\2\n\3/g;
+s/([<>][\n\x00])$/\1\n/;
+s/^(.*[\x00\n])?(\[\[|case|do|done|elif|else|esac|fi|for|function|if|in|select|then|time|until|while|&|;|&&|\|[|&]?)[\x00\n]//;
+s/^(\s*[\n\x00]|\w+=[^\n\x00]*[\n\x00])*//
+EOF
+)" \
         | tr \\0 \\n
 }
 

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -9,7 +9,7 @@ _fzf_bash_completion_egrep="$(command -v rg || command -v ag || echo egrep)"
 
 _fzf_bash_completion_shell_split() {
     "$_fzf_bash_completion_egrep" -o \
-        -e ';|\(|\)|\{|\}|&|\||:' \
+        -e '[;(){}&\|:]' \
         -e '\|+|&+' \
         -e "(\\\\.|[^\"'[:space:];:(){}&\\|])+" \
         -e "\\\$'(\\\\.|[^'])*('|$)" \

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -9,9 +9,9 @@ _fzf_bash_completion_egrep="$(command -v rg || command -v ag || echo egrep)"
 
 _fzf_bash_completion_shell_split() {
     "$_fzf_bash_completion_egrep" -o \
-        -e ';|\(|\)|\{|\}|&|\|' \
+        -e ';|\(|\)|\{|\}|&|\||:' \
         -e '\|+|&+' \
-        -e "(\\\\.|[^\"'[:space:];(){}&\\|])+" \
+        -e "(\\\\.|[^\"'[:space:];:(){}&\\|])+" \
         -e "\\\$'(\\\\.|[^'])*('|$)" \
         -e "'[^']*('|$)" \
         -e '"(\\.|\$($|[^(])|[^"$])*("|$)' \


### PR DESCRIPTION
These commits fix various issues with Bash completion with regards to `;`, `:`, `&`, `&&`, `|`, `||` and the various redirections (it should solve issue #17)

I took the liberty of both splitting the egrep command in `_fzf_bash_completion_shell_split` and generally rewriting the `sed`s in `_fzf_bash_completion_parse_line` to make them slightly more readable.