### PR TITLE
Bash completions - Fix use of complete -p

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -266,7 +266,13 @@ fzf_bash_completer() {
 
 _fzf_bash_completion_complete() {
     local compgen_actions=()
-    local compspec="$(complete -p "$1" 2>/dev/null || complete -p '')"
+    if [[ $1 =~ ^- ]]; then
+        # Don't actually use complete with something that will be
+        # interpreted as an argument to complete. Just fake it.
+        local compspec="$(complete -p '') $1"
+    else
+        local compspec="$(complete -p "$1" 2>/dev/null || { complete -p ''; echo "$1"; })"
+    fi
 
     eval "compspec=( $compspec )"
     set -- "${compspec[@]}" "$@"


### PR DESCRIPTION
- When completions are generated, `complete -p` should not be used if whatever is being completed could be interpreted as an option to complete.

- When there is no specific completion and `complete -p ''` has to be used, reinject the actual command into the output

This should fix issue #21 and an undetected issue with trying to complete after a string that starts with a dash.