### PR TITLE
Remove ag, as it doesn't support -e option.

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -5,7 +5,7 @@ _fzf_bash_completion_awk_escape() {
 }
 
 # shell parsing stuff
-_fzf_bash_completion_egrep="$( { which rg || which ag || echo egrep; } 2>/dev/null)"
+_fzf_bash_completion_egrep="$( { which rg || echo egrep; } 2>/dev/null)"
 
 _fzf_bash_completion_shell_split() {
     "$_fzf_bash_completion_egrep" -o \


### PR DESCRIPTION
Silver searcher doesn't support the -e option. Removed from the grep list.