### PR TITLE
try use gnu grep for better performance on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ rather than [creating a new mechanism](https://github.com/junegunn/fzf/wiki/Exam
 ## Installation
 
 1. You need to [install fzf](https://github.com/junegunn/fzf#installation) first.
-1. On OSX, you also need to GNU awk, e.g. `brew install gawk`
+1. On OSX, you also need GNU `awk` and GNU `grep`, e.g. `brew install gawk grep`
 1. Clone this repository: `git clone https://github.com/lincheney/fzf-tab-completion ...`
     * you can also choose to download only the scripts you need, up to you.
 1. Follow instructions on how to set up for:

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -1,15 +1,16 @@
 _FZF_COMPLETION_SEP=$'\x01'
 
 # shell parsing stuff
-_fzf_bash_completion_awk="$( { which gawk || echo awk; } 2>/dev/null)"
-_fzf_bash_completion_sed="$( { which gsed || echo sed; } 2>/dev/null)"
+_fzf_bash_completion_awk="$( builtin command -v gawk &>/dev/null && echo gawk || echo awk )"
+_fzf_bash_completion_sed="$( builtin command -v gsed &>/dev/null && echo gsed || echo sed )"
+_fzf_bash_completion_grep="$( builtin command -v ggrep &>/dev/null && echo ggrep || echo builtin command grep )"
 
 _fzf_bash_completion_awk_escape() {
     "$_fzf_bash_completion_sed" 's/\\/\\\\\\\\/g; s/[[*^$.]/\\\\&/g' <<<"$1"
 }
 
 _fzf_bash_completion_shell_split() {
-    command grep -E -o \
+    "$_fzf_bash_completion_grep" -E -o \
         -e '[;(){}&\|:]' \
         -e '\|+|&+' \
         -e "(\\\\.|[^\"'[:space:];:(){}&\\|])+" \
@@ -58,7 +59,7 @@ _fzf_bash_completion_find_matching_bracket() {
         else
             (( count -- ))
         fi
-    done < <(command grep -F -e '(' -e ')' -n)
+    done < <("$_fzf_bash_completion_grep" -F -e '(' -e ')' -n)
     return 1
 }
 
@@ -72,8 +73,8 @@ _fzf_bash_completion_parse_dq() {
         while true; do
             # we are in a double quoted string
 
-            shell_start="$(<<<"$line" command grep -E -o '^(\\.|\$[^(]|[^$])*\$\(')"
-            string_end="$(<<<"$line" command grep -E -o '^(\\.|[^"])*"')"
+            shell_start="$(<<<"$line" "$_fzf_bash_completion_grep" -E -o '^(\\.|\$[^(]|[^$])*\$\(')"
+            string_end="$(<<<"$line" "$_fzf_bash_completion_grep" -E -o '^(\\.|[^"])*"')"
 
             if (( ${#string_end} && ( ! ${#shell_start} || ${#string_end} < ${#shell_start} )  )); then
                 # found end of string

--- a/zsh/fzf-zsh-completion.sh
+++ b/zsh/fzf-zsh-completion.sh
@@ -9,7 +9,8 @@ _FZF_COMPLETION_FLAGS=( a k f q Q e n U l 1 2 C )
 zmodload zsh/zselect
 zmodload zsh/system
 
-_fzf_bash_completion_awk="$( { which gawk || echo awk; } 2>/dev/null)"
+_fzf_bash_completion_awk="$( builtin command -v gawk &>/dev/null && echo gawk || echo awk )"
+_fzf_bash_completion_grep="$( builtin command -v ggrep &>/dev/null && echo ggrep || echo grep )"
 
 fzf_completion() {
     emulate -LR zsh +o ALIASES
@@ -47,7 +48,7 @@ fzf_completion() {
 
         # all except autoload functions
         local full_variables="$(typeset -p)"
-        local full_functions="$(functions + | grep -F -vx "$(functions -u +)")"
+        local full_functions="$(functions + | "$_fzf_bash_completion_grep"  -F -vx "$(functions -u +)")"
 
         # do not allow grouping, it stuffs up display strings
         zstyle ":completion:*:*" list-grouped no
@@ -76,8 +77,8 @@ fzf_completion() {
                 stderr="$(
                     _fzf_completion_preexit() {
                         trap -
-                        functions + | grep -F -vx -e "$(functions -u +)" -e "$full_functions" | while read -r f; do which -- "$f"; done >&"${__evaled}"
-                        { typeset -p -- $(typeset + | grep -vF 'local ' | "$_fzf_bash_completion_awk" '{print $NF}') | grep -xvFf <(printf %s "$full_variables") >&"${__evaled}" } 2>/dev/null
+                        functions + | "$_fzf_bash_completion_grep"  -F -vx -e "$(functions -u +)" -e "$full_functions" | while read -r f; do which -- "$f"; done >&"${__evaled}"
+                        { typeset -p -- $(typeset + | "$_fzf_bash_completion_grep"  -vF 'local ' | "$_fzf_bash_completion_awk" '{print $NF}') | grep -xvFf <(printf %s "$full_variables") >&"${__evaled}" } 2>/dev/null
                     }
                     trap _fzf_completion_preexit EXIT TERM
                     _main_complete 2>&1


### PR DESCRIPTION
also use `builtin command -v` instead of `which` as there may be different types of `which` on a system

possibly related to some of the chatter in https://github.com/lincheney/fzf-tab-completion/issues/61
this will speed up the time it takes for `fzf` to start showing the completion list on mac if `ggrep` is installed
don't believe this is causing the `zsh` performance issue the person in the gif has

needs a `README` update suggesting a `brew install grep`