### PR TITLE
readline: use builtin command instead of which

### DIFF
--- a/readline/bin/rl_custom_complete
+++ b/readline/bin/rl_custom_complete
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-sed="$( { which gsed || echo sed; } 2>/dev/null)"
+sed="$( builtin command -v gsed &>/dev/null && echo gsed || echo sed )"
 
 prefix="$(<<<"$1" "$sed" 's/[[*^$.]/\\&/g')"
 sed "s/^$(<<<"$1" "$sed" 's/././g')/\x1b[37m&\x1b[0m/" \


### PR DESCRIPTION
this is probably a good change for parity sake
i've not had this issue on bash

@lincheney 