### PR TITLE
Update raw_comp_words instead of COMP_WORDS

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -300,6 +300,8 @@ _fzf_bash_completion_expand_alias() {
         if [ -n "${value[*]}" -a "${value[0]}" != "$1" ]; then
             printf '%s\n' "${value[@]}" "${@:2}"
         fi
+    else
+        printf '%s\n' "${@}"
     fi
 }
 

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -238,7 +238,7 @@ fzf_bash_completion() {
     fi
 
     if [[ ${#raw_comp_words[@]} -gt 1 ]]; then
-        _fzf_bash_completion_expand_alias "${raw_comp_words[0]}"
+        readarray -t raw_comp_words < <(_fzf_bash_completion_expand_alias "${raw_comp_words[@]}")
     fi
     readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)
 
@@ -298,7 +298,7 @@ _fzf_bash_completion_expand_alias() {
     if alias "$1" &>/dev/null; then
         value=( ${BASH_ALIASES[$1]} )
         if [ -n "${value[*]}" -a "${value[0]}" != "$1" ]; then
-            COMP_WORDS=( "${value[@]}" "${COMP_WORDS[@]:1}" )
+            printf '%s\n' "${value[@]}" "${@:2}"
         fi
     fi
 }


### PR DESCRIPTION
In _fzf_bash_completion_expand_alias() updating COMP_WORDS results in loss of expansion as _fzf_bash_completion_unquote_strings() uses raw_comp_words for further modifications.