### PR TITLE
bash: improve compatibility to bash v4.2 and before

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -255,8 +255,8 @@ fzf_bash_completion() {
     # add an extra blank word if last word is just space
     if [[ "${#COMP_WORDS[@]}" = 0 ]]; then
         COMP_WORDS+=( '' )
-    elif ! [[ "${COMP_WORDS[-1]}" =~ [^[:space:]] ]]; then
-        COMP_WORDS[-1]=''
+    elif ! [[ "${COMP_WORDS[${#COMP_WORDS[@]}-1]}" =~ [^[:space:]] ]]; then
+        COMP_WORDS[${#COMP_WORDS[@]}-1]=''
     fi
     COMP_CWORD="${#COMP_WORDS[@]}"
     (( COMP_CWORD-- ))


### PR DESCRIPTION
Bash v4.2 and before didn't support [negative subscripts](https://stackoverflow.com/a/40132058). This commit changes the index selection to `array[len(array)-1]` to fix the errors before Bash v4.2:

>  bash: COMP_WORDS[-1]: bad array subscript