### PR TITLE
Add $FZF_COMPLETION_TMUX_LEGACY for Flexible tmux Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,34 @@ You may find that adding the `fzf` flag `--tiebreak=chunk` to the environment va
 
 #### tmux
 
-`$FZF_TMUX_OPTS` is respected same as in [fzf](https://github.com/junegunn/fzf#key-bindings-for-command-line)
-however you must have fzf's keybindings enabled as well.
+`$FZF_TMUX_OPTS` is respected same as in [fzf](https://github.com/junegunn/fzf#key-bindings-for-command-line), and you must have fzf's keybindings enabled as well.
+
+Starting with this version, you can configure how fzf integrates with tmux using the `$FZF_COMPLETION_TMUX_LEGACY` environment variable:
+
+- **`true`** (default): Uses the legacy behavior with the `fzf-tmux` wrapper.
+- **`false`**: Enables the native `fzf --tmux` option, which fixes certain issues where `fzf-tmux` commands like `fzf-tmux --height=40% --` would fail with errors (`bash: fzf-tmux --height=40% --: command not found`).
+
+To switch to the new behavior:
+
+```bash
+export FZF_COMPLETION_TMUX_LEGACY=false
+```
+
+````
+If you haven’t already enabled fzf’s tmux mode, you can do so by following this simple tip from the [fzf README](https://github.com/junegunn/fzf?tab=readme-ov-file#--tmux-mode):
+
+```bash
+export FZF_TMUX=1
+````
+
+> [!TIP]
+> You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
+> default. For example,
+>
+> ```sh
+> # Open in tmux popup if on tmux, otherwise use --height mode
+> export FZF_DEFAULT_OPTS='--height 40% --tmux bottom,40% --layout reverse --border top'
+> ```
 
 #### Searching display strings
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ You may find that adding the `fzf` flag `--tiebreak=chunk` to the environment va
 
 `$FZF_TMUX_OPTS` is respected same as in [fzf](https://github.com/junegunn/fzf#key-bindings-for-command-line), and you must have fzf's keybindings enabled as well.
 
-Starting with this version, you can configure how fzf integrates with tmux using the `$FZF_COMPLETION_TMUX_LEGACY` environment variable:
+You can configure how fzf integrates with tmux using the `$FZF_COMPLETION_TMUX_LEGACY` environment variable:
 
 - **`true`** (default): Uses the legacy behavior with the `fzf-tmux` wrapper.
-- **`false`**: Enables the native `fzf --tmux` option, which fixes certain issues where `fzf-tmux` commands like `fzf-tmux --height=40% --` would fail with errors (`bash: fzf-tmux --height=40% --: command not found`).
+- **`false`**: Enables support for --tmux mode in fzf (`fzf --tmux` option), which fixes certain issues where `fzf-tmux` commands like `fzf-tmux --height=40% --` would fail with errors (`bash: fzf-tmux --height=40% --: command not found`).
 
 To switch to the new behavior:
 
@@ -73,7 +73,6 @@ To switch to the new behavior:
 export FZF_COMPLETION_TMUX_LEGACY=false
 ```
 
-````
 If you haven’t already enabled fzf’s tmux mode, you can do so by following this simple tip from the [fzf README](https://github.com/junegunn/fzf?tab=readme-ov-file#--tmux-mode):
 
 ```bash
@@ -81,7 +80,7 @@ export FZF_TMUX=1
 ````
 
 > [!TIP]
-> You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
+> Add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
 > default. For example,
 >
 > ```sh

--- a/README.md
+++ b/README.md
@@ -5,43 +5,48 @@ Tab completion using fzf in zsh, bash, GNU readline apps (e.g. `python`, `php -a
 This is distinct from
 [fzf's own implementation for completion](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh),
 in that it works _with_ the existing completion mechanisms
-rather than [creating a new mechanism](https://github.com/junegunn/fzf/wiki/Examples-(completion)).
+rather than [creating a new mechanism](<https://github.com/junegunn/fzf/wiki/Examples-(completion)>).
 
 ## Example
+
 <details><summary>Click here to show screencast</summary>
 
 ![Example](./example.svg)
+
 </details>
 
 ## Installation
 
 1. You need to [install fzf](https://github.com/junegunn/fzf#installation) first.
 1. If you are using OSX you may need to install some additional things:
-    * e.g. `brew install gawk grep gnu-sed coreutils`
+   - e.g. `brew install gawk grep gnu-sed coreutils`
 1. Clone this repository: `git clone https://github.com/lincheney/fzf-tab-completion ...`
-    * you can also choose to download only the scripts you need, up to you.
+   - you can also choose to download only the scripts you need, up to you.
 1. Follow instructions on how to set up for:
-    * [zsh](#zsh)
-    * [bash](#bash)
-    * [readline](#readline)
-    * [nodejs](#nodejs-repl)
-    * [python3](#python3)
+   - [zsh](#zsh)
+   - [bash](#bash)
+   - [readline](#readline)
+   - [nodejs](#nodejs-repl)
+   - [python3](#python3)
 1. The following environment variables are supported, just as in fzf's "vanilla" completion.
-    * `$FZF_TMUX_HEIGHT`
-    * `$FZF_COMPLETION_OPTS`
-    * `$FZF_DEFAULT_OPTS`
 
-    See also <https://github.com/junegunn/fzf#settings>
+   - `$FZF_TMUX_HEIGHT`
+   - `$FZF_COMPLETION_OPTS`
+   - `$FZF_DEFAULT_OPTS`
 
-    Avoid changing these `fzf` flags: `-n`, `--nth`, `--with-nth`, `-d`
+   See also <https://github.com/junegunn/fzf#settings>
+
+   Avoid changing these `fzf` flags: `-n`, `--nth`, `--with-nth`, `-d`
 
 ## zsh
 
 Add to your `~/.zshrc`:
+
 ```bash
 source /path/to/fzf-tab-completion/zsh/fzf-zsh-completion.sh
 bindkey '^I' fzf_completion
 ```
+
 If you have also enabled fzf's zsh completion, then the `bindkey` line is optional.
 
 Note that this does not provide `**`-style triggers,
@@ -62,6 +67,7 @@ however you must have fzf's keybindings enabled as well.
 
 By default, display strings are shown but cannot be searched in fzf.
 This is configurable via `zstyle`:
+
 ```bash
 # only for git
 zstyle ':completion:*:*:git:*' fzf-search-display true
@@ -71,11 +77,11 @@ zstyle ':completion:*' fzf-search-display true
 
 #### Specifying keybindings
 
-You can specify `fzf` keybindings to execute shell commands *after* `fzf` has closed.
+You can specify `fzf` keybindings to execute shell commands _after_ `fzf` has closed.
 This is configurable via the `fzf-completion-keybindings` zstyle.
 
 Keybinds look like: `KEY:SCRIPT`
-When `KEY` is pressed, `fzf` will *exit* and the zsh `SCRIPT` will run.
+When `KEY` is pressed, `fzf` will _exit_ and the zsh `SCRIPT` will run.
 If the keybind is given in the form `KEY:accept:SCRIPT` then the selected matches will also be completed before `SCRIPT` is run.
 `KEY` is any valid `fzf` key.
 
@@ -132,10 +138,11 @@ done'
 
 #### changing display string color
 
-By default, the display string and the input prefix (i.e. the parts of the strings that are *not* searchable)
-are highlighted with `\x1b[37m` which *should* come out as a light grey.
+By default, the display string and the input prefix (i.e. the parts of the strings that are _not_ searchable)
+are highlighted with `\x1b[37m` which _should_ come out as a light grey.
 
 You can change this with the `fzf-completion-secondary-color` zstyle, e.g.:
+
 ```bash
 # make it red instead
 zstyle ':completion:*' fzf-completion-secondary-color red
@@ -148,6 +155,7 @@ If set to an empty string, no color will be applied at all.
 ## bash
 
 Add to your `~/.bashrc`:
+
 ```bash
 source /path/to/fzf-tab-completion/bash/fzf-bash-completion.sh
 bind -x '"\t": fzf_bash_completion'
@@ -163,19 +171,21 @@ you may prefer (or not!) to use the [readline](#readline) method instead.
 
 The `FZF_TAB_COMPLETION_PROMPT` environment variable sets the prompt prefix
 The default is `'> '`.
-You could, for example, change it to `FZF_TAB_COMPLETION_PROMPT='❯ '`. 
+You could, for example, change it to `FZF_TAB_COMPLETION_PROMPT='❯ '`.
 
 #### Autocomplete common prefix
 
 By default, fzf is always shown whenever there are at least 2 matches.
 You can change this to a more "vanilla" tab completion experience where
-it attempts to complete the longest common prefix *before* showing matches in fzf.
+it attempts to complete the longest common prefix _before_ showing matches in fzf.
 
 This is controlled by the variables
-* `FZF_COMPLETION_AUTO_COMMON_PREFIX=true` - completes the common prefix if it is also a match
-* `FZF_COMPLETION_AUTO_COMMON_PREFIX_PART=true` - with the above variable, completes the common prefix even if it is not a match
+
+- `FZF_COMPLETION_AUTO_COMMON_PREFIX=true` - completes the common prefix if it is also a match
+- `FZF_COMPLETION_AUTO_COMMON_PREFIX_PART=true` - with the above variable, completes the common prefix even if it is not a match
 
 For example, if we have following files in a directory:
+
 ```
 abcdef-1234
 abcdef-5678
@@ -184,13 +194,14 @@ other
 ```
 
 With `FZF_COMPLETION_AUTO_COMMON_PREFIX=true`:
-* when completing `ls <tab>`, it will display fzf with all 4 files (as normal)
-* when completing `ls a<tab>`, it will automatically complete to `ls abc`.
-    Pressing tab again will show fzf with the first 3 files.
-* when completing `ls abcd<tab>` it will show fzf with the first 2 files (as normal)
-* With `FZF_COMPLETION_AUTO_COMMON_PREFIX_PART=true` set as well:
-    * when completing `ls abcd<tab>`, it will automatically complete to `ls abcdef-`.
-        Pressing tab again will show fzf with the first 2 files.
+
+- when completing `ls <tab>`, it will display fzf with all 4 files (as normal)
+- when completing `ls a<tab>`, it will automatically complete to `ls abc`.
+  Pressing tab again will show fzf with the first 3 files.
+- when completing `ls abcd<tab>` it will show fzf with the first 2 files (as normal)
+- With `FZF_COMPLETION_AUTO_COMMON_PREFIX_PART=true` set as well:
+  - when completing `ls abcd<tab>`, it will automatically complete to `ls abcdef-`.
+    Pressing tab again will show fzf with the first 2 files.
 
 #### tmux
 
@@ -207,6 +218,7 @@ You can customise the message by overriding the `_fzf_bash_completion_loading_ms
 For example the following "re-prints" the prompt and input line
 to make this less jarring
 (note this may or may not work, there's no detection of `$PS2` and there is always some unavoidable flicker):
+
 ```bash
 _fzf_bash_completion_loading_msg() { echo "${PS1@P}${READLINE_LINE}" | tail -n1; }
 ```
@@ -214,67 +226,74 @@ _fzf_bash_completion_loading_msg() { echo "${PS1@P}${READLINE_LINE}" | tail -n1;
 ## readline
 
 NOTE: This uses a `LD_PRELOAD` hack, is only supported on Linux and only for GNU readline
-(*not* e.g. libedit or other readline alternatives).
+(_not_ e.g. libedit or other readline alternatives).
 
 1. Run: `cd /path/to/fzf-tab-completion/readline/ && cargo build --release`
 1. Copy/symlink `/path/to/fzf-tab-completion/readline/bin/rl_custom_complete` into your `$PATH`
 1. Add to your `~/.inputrc`:
+
    ```
    $include function rl_custom_complete /path/to/fzf-tab-completion/readline/target/release/librl_custom_complete.so
    "\t": rl_custom_complete
    ```
-1. Build https://github.com/lincheney/rl_custom_function/
-   * this should produce a file `librl_custom_function.so` which you will use with `LD_PRELOAD` in the next step.
+
+1. Build <https://github.com/lincheney/rl_custom_function/>
+   - this should produce a file `librl_custom_function.so` which you will use with `LD_PRELOAD` in the next step.
 1. Run something interactive that uses readline, e.g. python:
+
    ```bash
    LD_PRELOAD=/path/to/librl_custom_function.so python
    ```
+
 1. To apply this all applications more permanently,
    you will need to set `LD_PRELOAD` somewhere like `/etc/environment` or `~/.pam_environment`.
-   * NOTE: if you set `LD_PRELOAD` in your `.bashrc`, or similar, it will affect applications run _from_ `bash`
-      but not the parent `bash` process itself.
-   * See also: [link](https://wiki.archlinux.org/index.php/Environment_variables#Per_user)
+   - NOTE: if you set `LD_PRELOAD` in your `.bashrc`, or similar, it will affect applications run _from_ `bash`
+     but not the parent `bash` process itself.
+   - See also: [link](https://wiki.archlinux.org/index.php/Environment_variables#Per_user)
 
 These are the applications that I have seen working:
-* `python2`, `python3`
-    * only `PYTHON_BASIC_REPL=1 python3` if python 3.13+, otherwise see [python3](#python3)
-* `php -a`
-* `R`
-* `lftp`
-* `irb --legacy` (the new `irb` in ruby 2.7 uses `ruby-reline` instead of readline)
-* `gdb`
-* `sqlite3`
-* `bash` (only when not statically but dynamically linked to libreadline)
+
+- `python2`, `python3`
+  - only `PYTHON_BASIC_REPL=1 python3` if python 3.13+, otherwise see [python3](#python3)
+- `php -a`
+- `R`
+- `lftp`
+- `irb --legacy` (the new `irb` in ruby 2.7 uses `ruby-reline` instead of readline)
+- `gdb`
+- `sqlite3`
+- `bash` (only when not statically but dynamically linked to libreadline)
 
 ## nodejs repl
 
 1. Copy/symlink `/path/to/fzf-tab-completion/node/rl_custom_complete` into your `$PATH`
 1. Then run `node -r /path/to/fzf-tab-completion.git/node/fzf-node-completion.js`
-    * You may wish to add a shell alias to your `~/.zshrc`/`~/.bashrc` to avoid typing out the full command each time, e.g.:
-        `alias node='node -r /path/to/fzf-tab-completion.git/node/fzf-node-completion.js`
+   - You may wish to add a shell alias to your `~/.zshrc`/`~/.bashrc` to avoid typing out the full command each time, e.g.:
+     `alias node='node -r /path/to/fzf-tab-completion.git/node/fzf-node-completion.js`
 
 ## python3
 
 1. Copy/symlink `/path/to/fzf-tab-completion/python/rl_custom_complete` into your `$PATH`
 1. Add the code below to either:
-    * your `~/.pythonstartup`
-    * your `$PYTHONPATH/usercustomize.py`
-        * see <https://docs.python.org/3/tutorial/appendix.html#the-customization-modules>
-        * for example, I have `export PYTHONPATH=$HOME/dotfiles/pythonpath` and a file `$HOME/dotfiles/pythonpath/usercustomize.py`
+   - your `~/.pythonstartup`
+   - your `$PYTHONPATH/usercustomize.py`
+     - see <https://docs.python.org/3/tutorial/appendix.html#the-customization-modules>
+     - for example, I have `export PYTHONPATH=$HOME/dotfiles/pythonpath` and a file `$HOME/dotfiles/pythonpath/usercustomize.py`
+
 ```python
 with open('/path/to/fzf-tab-completion.git/python/fzf_python_completion.py') as file:
     exec(file.read())
 ```
 
 This should work with:
-* a normal python shell `python3`, including the new interactive shell from 3.13+
-* the old interactive shell i.e. `PYTHON_BASIC_REPL=1 python3`
-* (only when added to `usercustomize.py`) anything that uses `readline.set_completer(...)`, including:
-    * `python3 -m asyncio`
-    * `pdb` / `breakpoint()`
+
+- a normal python shell `python3`, including the new interactive shell from 3.13+
+- the old interactive shell i.e. `PYTHON_BASIC_REPL=1 python3`
+- (only when added to `usercustomize.py`) anything that uses `readline.set_completer(...)`, including:
+  - `python3 -m asyncio`
+  - `pdb` / `breakpoint()`
 
 ## Related projects
 
-* <https://github.com/rockandska/fzf-obc> (fzf tab completion in bash)
-* <https://github.com/Aloxaf/fzf-tab> (fzf tab completion in zsh)
-* <https://github.com/lincheney/rl_custom_isearch> (fzf for history search in all readline applications)
+- <https://github.com/rockandska/fzf-obc> (fzf tab completion in bash)
+- <https://github.com/Aloxaf/fzf-tab> (fzf tab completion in zsh)
+- <https://github.com/lincheney/rl_custom_isearch> (fzf for history search in all readline applications)

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -1,152 +1,153 @@
 _FZF_COMPLETION_SEP=$'\x01'
 
 # shell parsing stuff
-_fzf_bash_completion_awk="$( builtin command -v gawk &>/dev/null && echo gawk || echo awk )"
-_fzf_bash_completion_sed="$( builtin command -v gsed &>/dev/null && echo gsed || echo sed )"
-_fzf_bash_completion_grep="$( builtin command -v ggrep &>/dev/null && echo ggrep || echo builtin command grep )"
+_fzf_bash_completion_awk="$(builtin command -v gawk &>/dev/null && echo gawk || echo awk)"
+_fzf_bash_completion_sed="$(builtin command -v gsed &>/dev/null && echo gsed || echo sed)"
+_fzf_bash_completion_grep="$(builtin command -v ggrep &>/dev/null && echo ggrep || echo builtin command grep)"
 
 _fzf_bash_completion_awk_escape() {
-    "$_fzf_bash_completion_sed" 's/\\/\\\\\\\\/g; s/[[*^$.]/\\\\&/g' <<<"$1"
+  "$_fzf_bash_completion_sed" 's/\\/\\\\\\\\/g; s/[[*^$.]/\\\\&/g' <<<"$1"
 }
 
 _fzf_bash_completion_shell_split() {
-    $_fzf_bash_completion_grep -E -o \
-        -e '\|+|&+|<+|>+' \
-        -e '[;(){}&\|]' \
-        -e '(\\.|\$[-[:alnum:]_*@#?$!]|(\$\{[^}]*(\}|$))|[^$\|"[:space:];(){}&<>'"'${wordbreaks}])+" \
-        -e "\\\$'(\\\\.|[^'])*('|$)" \
-        -e "'[^']*('|$)" \
-        -e '"(\\.|\$($|[^(])|[^"$])*("|$)' \
-        -e '".*' \
-        -e '[[:space:]]+' \
-        -e .
+  $_fzf_bash_completion_grep -E -o \
+    -e '\|+|&+|<+|>+' \
+    -e '[;(){}&\|]' \
+    -e '(\\.|\$[-[:alnum:]_*@#?$!]|(\$\{[^}]*(\}|$))|[^$\|"[:space:];(){}&<>'"'${wordbreaks}])+" \
+    -e "\\\$'(\\\\.|[^'])*('|$)" \
+    -e "'[^']*('|$)" \
+    -e '"(\\.|\$($|[^(])|[^"$])*("|$)' \
+    -e '".*' \
+    -e '[[:space:]]+' \
+    -e .
 }
 
 _fzf_bash_completion_unbuffered_awk() {
-    # need to get awk to be unbuffered either by using -W interactive or system("")
-    "$_fzf_bash_completion_awk" -W interactive "${@:3}" "$1 { $2; print \$0; system(\"\") }" 2>/dev/null
+  # need to get awk to be unbuffered either by using -W interactive or system("")
+  "$_fzf_bash_completion_awk" -W interactive "${@:3}" "$1 { $2; print \$0; system(\"\") }" 2>/dev/null
 }
 
 _fzf_bash_completion_flatten_subshells() {
-    (
-        local count=0 buffer=
-        while IFS= read -r line; do
-            case "$line" in
-                \(|\{) (( count -- )) ;;
-                \)|\}) (( count ++ )) ;;
-            esac
+  (
+    local count=0 buffer=
+    while IFS= read -r line; do
+      case "$line" in
+      \( | \{) ((count--)) ;;
+      \) | \}) ((count++)) ;;
+      esac
 
-            if (( count < 0 )); then
-                return
-            elif (( count > 0 )); then
-                buffer="$line$buffer"
-            else
-                printf '%s\n' "$line$buffer"
-                buffer=
-            fi
-        done < <(tac)
-        printf '%s\n' "$buffer"
-    ) | tac
+      if ((count < 0)); then
+        return
+      elif ((count > 0)); then
+        buffer="$line$buffer"
+      else
+        printf '%s\n' "$line$buffer"
+        buffer=
+      fi
+    done < <(tac)
+    printf '%s\n' "$buffer"
+  ) | tac
 }
 
 _fzf_bash_completion_find_matching_bracket() {
-    local count=0
-    while IFS=: read -r num bracket; do
-        if [ "$bracket" = "$1" ]; then
-            (( count++ ))
-            if (( count > 0 )); then
-                printf '%s\n' "$num"
-                return 0
-            fi
-        else
-            (( count -- ))
-        fi
-    done < <($_fzf_bash_completion_grep -F -e '(' -e ')' -n)
-    return 1
+  local count=0
+  while IFS=: read -r num bracket; do
+    if [ "$bracket" = "$1" ]; then
+      ((count++))
+      if ((count > 0)); then
+        printf '%s\n' "$num"
+        return 0
+      fi
+    else
+      ((count--))
+    fi
+  done < <($_fzf_bash_completion_grep -F -e '(' -e ')' -n)
+  return 1
 }
 
 _fzf_bash_completion_parse_dq() {
-    local words="$(cat)"
-    local last="$(<<<"$words" tail -n1)"
+  local words="$(cat)"
+  local last="$(<<<"$words" tail -n1)"
 
-    if [[ "$last" == \"* ]]; then
-        local line="${last:1}" shell_start string_end joined num
-        local word=
-        while true; do
-            # we are in a double quoted string
+  if [[ "$last" == \"* ]]; then
+    local line="${last:1}" shell_start string_end joined num
+    local word=
+    while true; do
+      # we are in a double quoted string
 
-            shell_start="$(<<<"$line" $_fzf_bash_completion_grep -E -o '^(\\.|\$[^(]|[^$])*\$\(')"
-            string_end="$(<<<"$line" $_fzf_bash_completion_grep -E -o '^(\\.|[^"])*"')"
+      shell_start="$(<<<"$line" $_fzf_bash_completion_grep -E -o '^(\\.|\$[^(]|[^$])*\$\(')"
+      string_end="$(<<<"$line" $_fzf_bash_completion_grep -E -o '^(\\.|[^"])*"')"
 
-            if (( ${#string_end} && ( ! ${#shell_start} || ${#string_end} < ${#shell_start} )  )); then
-                # found end of string
-                line="${line:${#string_end}}"
-                if (( ${#line} )); then
-                    printf '%s\n' "${words:0:-${#line}}"
-                    _fzf_bash_completion_parse_line <<<"$line"
-                else
-                    printf '%s\n' "$words"
-                fi
-                return
+      if ((${#string_end} && (!${#shell_start} || ${#string_end} < ${#shell_start}))); then
+        # found end of string
+        line="${line:${#string_end}}"
+        if ((${#line})); then
+          printf '%s\n' "${words:0:-${#line}}"
+          _fzf_bash_completion_parse_line <<<"$line"
+        else
+          printf '%s\n' "$words"
+        fi
+        return
 
-            elif (( ${#shell_start} && ( ! ${#string_end} || ${#shell_start} < ${#string_end} )  )); then
-                # found a subshell
+      elif ((${#shell_start} && (!${#string_end} || ${#shell_start} < ${#string_end}))); then
+        # found a subshell
 
-                word+="${shell_start:0:-2}"
-                line="${line:${#shell_start}}"
+        word+="${shell_start:0:-2}"
+        line="${line:${#shell_start}}"
 
-                split="$(<<<"$line" _fzf_bash_completion_shell_split)"
-                if ! split="$(_fzf_bash_completion_parse_dq <<<"$split")"; then
-                    # bubble up
-                    printf '%s\n' "$split"
-                    return 1
-                fi
-                if ! num="$(_fzf_bash_completion_find_matching_bracket ')' <<<"$split")"; then
-                    # subshell not closed, this is it
-                    printf '%s\n' "$split"
-                    return 1
-                fi
-                # subshell closed
-                joined="$(<<<"$split" head -n "$num" | tr -d \\n)"
-                word+=$'\n$('"$joined"$'\n'
-                line="${line:${#joined}}"
+        split="$(<<<"$line" _fzf_bash_completion_shell_split)"
+        if ! split="$(_fzf_bash_completion_parse_dq <<<"$split")"; then
+          # bubble up
+          printf '%s\n' "$split"
+          return 1
+        fi
+        if ! num="$(_fzf_bash_completion_find_matching_bracket ')' <<<"$split")"; then
+          # subshell not closed, this is it
+          printf '%s\n' "$split"
+          return 1
+        fi
+        # subshell closed
+        joined="$(<<<"$split" head -n "$num" | tr -d \\n)"
+        word+=$'\n$('"$joined"$'\n'
+        line="${line:${#joined}}"
 
-            else
-                # the whole line is an incomplete string
-                break
-            fi
-        done
-    fi
-    printf '%s\n' "$words"
+      else
+        # the whole line is an incomplete string
+        break
+      fi
+    done
+  fi
+  printf '%s\n' "$words"
 }
 
 _fzf_bash_completion_unquote_strings() {
-    local line
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^\'[^\']*\'?$ ]]; then
-            # single quoted with no single quotes inside
-            line="${line%%"'"}"
-            printf '%s\n' "${line:1}"
-        elif [[ "$line" =~ ^\"(\\.|[^\"$])*\"?$ ]]; then
-            # double quoted with all special characters quoted
-            "$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"${line:1-1}"
-        elif [[ "$line" == *\\* && "$line" =~ ^(\\.|[a-zA-Z0-9_])*$ ]]; then
-            # all special characters are quoted
-            "$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"$line"
-        else
-            # this string is either boring or too complicated to parse
-            # print as is
-            printf '%s\n' "$line"
-        fi
-    done
+  local line
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^\'[^\']*\'?$ ]]; then
+      # single quoted with no single quotes inside
+      line="${line%%"'"}"
+      printf '%s\n' "${line:1}"
+    elif [[ "$line" =~ ^\"(\\.|[^\"$])*\"?$ ]]; then
+      # double quoted with all special characters quoted
+      "$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"${line:1-1}"
+    elif [[ "$line" == *\\* && "$line" =~ ^(\\.|[a-zA-Z0-9_])*$ ]]; then
+      # all special characters are quoted
+      "$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"$line"
+    else
+      # this string is either boring or too complicated to parse
+      # print as is
+      printf '%s\n' "$line"
+    fi
+  done
 }
 
 _fzf_bash_completion_parse_line() {
-    _fzf_bash_completion_shell_split \
-        | _fzf_bash_completion_parse_dq \
-        | _fzf_bash_completion_flatten_subshells \
-        | tr \\n \\0 \
-        | "$_fzf_bash_completion_sed" -r "$(cat <<'EOF'
+  _fzf_bash_completion_shell_split |
+    _fzf_bash_completion_parse_dq |
+    _fzf_bash_completion_flatten_subshells |
+    tr \\n \\0 |
+    "$_fzf_bash_completion_sed" -r "$(
+      cat <<'EOF'
 # collapse newlines
 s/\x00\x00/\x00/g;
 # leave trailing space
@@ -162,475 +163,489 @@ s/^(.*[\x00\n])?(\[\[|case|do|done|elif|else|esac|fi|for|function|if|in|select|t
 # remove ENVVAR=VALUE
 s/^(\s*[\n\x00]|\w+=[^\n\x00]*[\n\x00])*//
 EOF
-)" \
-        | tr \\0 \\n
+    )" |
+    tr \\0 \\n
 }
 
 _fzf_bash_completion_compspec() {
-    if [[ "$2" =~ .*\$(\{?)([A-Za-z0-9_]*)$ ]]; then
-        printf '%s\n' 'complete -F _fzf_bash_completion_complete_variables'
-    elif [[ "$COMP_CWORD" == 0 && -z "$2" ]]; then
-        # If the command word is the empty string (completion attempted at the beginning of an empty line), any compspec defined with the -E option to complete is used.
-        complete -p -E || { ! shopt -q no_empty_cmd_completion && printf '%s\n' 'complete -F _fzf_bash_completion_complete_commands -E'; }
-    elif [[ "$COMP_CWORD" == 0 ]]; then
-        complete -p -I || printf '%s\n' 'complete -F _fzf_bash_completion_complete_commands -I'
-    else
-       # If the command word is a full pathname, a compspec for the full pathname is searched for first.  If no compspec is found for the full pathname, an attempt is made to find a compspec for the portion following the final slash.  If those searches do not result in a compspec, any compspec defined with the -D option to complete is used as the default
-        complete -p -- "$1" || complete -p -- "${1##*/}" || complete -p -D || printf '%s\n' 'complete -o filenames -F _fzf_bash_completion_fallback_completer'
-    fi
+  if [[ "$2" =~ .*\$(\{?)([A-Za-z0-9_]*)$ ]]; then
+    printf '%s\n' 'complete -F _fzf_bash_completion_complete_variables'
+  elif [[ "$COMP_CWORD" == 0 && -z "$2" ]]; then
+    # If the command word is the empty string (completion attempted at the beginning of an empty line), any compspec defined with the -E option to complete is used.
+    complete -p -E || { ! shopt -q no_empty_cmd_completion && printf '%s\n' 'complete -F _fzf_bash_completion_complete_commands -E'; }
+  elif [[ "$COMP_CWORD" == 0 ]]; then
+    complete -p -I || printf '%s\n' 'complete -F _fzf_bash_completion_complete_commands -I'
+  else
+    # If the command word is a full pathname, a compspec for the full pathname is searched for first.  If no compspec is found for the full pathname, an attempt is made to find a compspec for the portion following the final slash.  If those searches do not result in a compspec, any compspec defined with the -D option to complete is used as the default
+    complete -p -- "$1" || complete -p -- "${1##*/}" || complete -p -D || printf '%s\n' 'complete -o filenames -F _fzf_bash_completion_fallback_completer'
+  fi
 }
 
 _fzf_bash_completion_fallback_completer() {
-    # fallback completion in case no compspecs loaded
-    if [[ "$1" == \~* && "$1" != */* ]]; then
-        # complete ~user directories
-        readarray -t COMPREPLY < <(compgen -P '~' -u -- "${1#\~}")
-    else
-        # complete files
-        readarray -t COMPREPLY < <(compgen -f -- "$1")
-    fi
+  # fallback completion in case no compspecs loaded
+  if [[ "$1" == \~* && "$1" != */* ]]; then
+    # complete ~user directories
+    readarray -t COMPREPLY < <(compgen -P '~' -u -- "${1#\~}")
+  else
+    # complete files
+    readarray -t COMPREPLY < <(compgen -f -- "$1")
+  fi
 }
 
 _fzf_bash_completion_complete_commands() {
-    # commands
-    compopt -o filenames
-    readarray -t COMPREPLY < <(compgen -abc -- "$2")
+  # commands
+  compopt -o filenames
+  readarray -t COMPREPLY < <(compgen -abc -- "$2")
 }
 
 _fzf_bash_completion_complete_variables() {
-    if [[ "$2" =~ .*\$(\{?)([A-Za-z0-9_]*)$ ]]; then
-        # environment variables
-        local brace="${BASH_REMATCH[1]}"
-        local filter="${BASH_REMATCH[2]}"
-        if [ -n "$filter" ]; then
-            local prefix="${2:: -${#filter}}"
-        else
-            local prefix="$2"
-        fi
-        readarray -t COMPREPLY < <(compgen -v -P "$prefix" -S "${brace:+\}}" -- "$filter")
+  if [[ "$2" =~ .*\$(\{?)([A-Za-z0-9_]*)$ ]]; then
+    # environment variables
+    local brace="${BASH_REMATCH[1]}"
+    local filter="${BASH_REMATCH[2]}"
+    if [ -n "$filter" ]; then
+      local prefix="${2::-${#filter}}"
+    else
+      local prefix="$2"
     fi
+    readarray -t COMPREPLY < <(compgen -v -P "$prefix" -S "${brace:+\}}" -- "$filter")
+  fi
 }
 
 _fzf_bash_completion_loading_msg() {
-    echo 'Loading matches ...'
+  echo 'Loading matches ...'
 }
 
 fzf_bash_completion() {
-    # bail early if no_empty_cmd_completion
-    if ! [[ "$READLINE_LINE" =~ [^[:space:]] ]] && shopt -q no_empty_cmd_completion; then
-        return 1
-    fi
+  # bail early if no_empty_cmd_completion
+  if ! [[ "$READLINE_LINE" =~ [^[:space:]] ]] && shopt -q no_empty_cmd_completion; then
+    return 1
+  fi
 
-    printf '\r'
-    command tput sc 2>/dev/null || echo -ne "\0337"
-    printf '%s' "$(_fzf_bash_completion_loading_msg)"
-    command tput rc 2>/dev/null || echo -ne "\0338"
+  printf '\r'
+  command tput sc 2>/dev/null || echo -ne "\0337"
+  printf '%s' "$(_fzf_bash_completion_loading_msg)"
+  command tput rc 2>/dev/null || echo -ne "\0338"
 
-    local raw_comp_words=()
-    local COMP_WORDS=() COMP_CWORD COMP_POINT COMP_LINE
-    local COMP_TYPE=37 # % == indicates menu completion
-    local line="${READLINE_LINE:0:READLINE_POINT}"
-    local wordbreaks="$COMP_WORDBREAKS"
-    wordbreaks="${wordbreaks//[]^]/\\&}"
-    wordbreaks="${wordbreaks//[[:space:]]/}"
-    if [[ "$line" =~ [^[:space:]] ]]; then
-        readarray -t raw_comp_words < <(_fzf_bash_completion_parse_line <<<"$line")
-    fi
+  local raw_comp_words=()
+  local COMP_WORDS=() COMP_CWORD COMP_POINT COMP_LINE
+  local COMP_TYPE=37 # % == indicates menu completion
+  local line="${READLINE_LINE:0:READLINE_POINT}"
+  local wordbreaks="$COMP_WORDBREAKS"
+  wordbreaks="${wordbreaks//[]^]/\\&}"
+  wordbreaks="${wordbreaks//[[:space:]]/}"
+  if [[ "$line" =~ [^[:space:]] ]]; then
+    readarray -t raw_comp_words < <(_fzf_bash_completion_parse_line <<<"$line")
+  fi
 
-    if [[ ${#raw_comp_words[@]} -gt 1 ]]; then
-        _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
-    fi
-    readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)
+  if [[ ${#raw_comp_words[@]} -gt 1 ]]; then
+    _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
+  fi
+  readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)
 
-    printf -v COMP_LINE '%s' "${COMP_WORDS[@]}"
-    COMP_POINT="${#COMP_LINE}"
-    # remove the ones that just spaces
-    local i
-    # iterate in reverse
-    for (( i = ${#COMP_WORDS[@]}-2; i >= 0; i --)); do
-        if ! [[ "${COMP_WORDS[i]}" =~ [^[:space:]] ]]; then
-            COMP_WORDS=( "${COMP_WORDS[@]:0:i}" "${COMP_WORDS[@]:i+1}" )
-        fi
-    done
-    # add an extra blank word if last word is just space
-    if [[ "${#COMP_WORDS[@]}" = 0 ]]; then
-        COMP_WORDS+=( '' )
-    elif ! [[ "${COMP_WORDS[${#COMP_WORDS[@]}-1]}" =~ [^[:space:]] ]]; then
-        COMP_WORDS[${#COMP_WORDS[@]}-1]=''
+  printf -v COMP_LINE '%s' "${COMP_WORDS[@]}"
+  COMP_POINT="${#COMP_LINE}"
+  # remove the ones that just spaces
+  local i
+  # iterate in reverse
+  for ((i = ${#COMP_WORDS[@]} - 2; i >= 0; i--)); do
+    if ! [[ "${COMP_WORDS[i]}" =~ [^[:space:]] ]]; then
+      COMP_WORDS=("${COMP_WORDS[@]:0:i}" "${COMP_WORDS[@]:i+1}")
     fi
-    COMP_CWORD="${#COMP_WORDS[@]}"
-    (( COMP_CWORD-- ))
+  done
+  # add an extra blank word if last word is just space
+  if [[ "${#COMP_WORDS[@]}" = 0 ]]; then
+    COMP_WORDS+=('')
+  elif ! [[ "${COMP_WORDS[${#COMP_WORDS[@]} - 1]}" =~ [^[:space:]] ]]; then
+    COMP_WORDS[${#COMP_WORDS[@]} - 1]=''
+  fi
+  COMP_CWORD="${#COMP_WORDS[@]}"
+  ((COMP_CWORD--))
 
-    local cmd="${COMP_WORDS[0]}"
-    local prev
-    if [ "$COMP_CWORD" = 0 ]; then
-        prev=
-    else
-        prev="${COMP_WORDS[COMP_CWORD-1]}"
-    fi
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    if [[ "$cur" =~ ^[$wordbreaks]$ ]]; then
-        cur=
-    fi
-    local raw_cur="${cur:+${raw_comp_words[-1]}}"
+  local cmd="${COMP_WORDS[0]}"
+  local prev
+  if [ "$COMP_CWORD" = 0 ]; then
+    prev=
+  else
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+  fi
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  if [[ "$cur" =~ ^[$wordbreaks]$ ]]; then
+    cur=
+  fi
+  local raw_cur="${cur:+${raw_comp_words[-1]}}"
 
-    local COMPREPLY=
-    fzf_bash_completer "$cmd" "$cur" "$prev"
-    if [ -n "$COMPREPLY" ]; then
-        if [ -n "$raw_cur" ]; then
-            line="${line::-${#raw_cur}}"
-        fi
-        READLINE_LINE="${line}${COMPREPLY}${READLINE_LINE:$READLINE_POINT}"
-        (( READLINE_POINT+=${#COMPREPLY} - ${#raw_cur} ))
+  local COMPREPLY=
+  fzf_bash_completer "$cmd" "$cur" "$prev"
+  if [ -n "$COMPREPLY" ]; then
+    if [ -n "$raw_cur" ]; then
+      line="${line::-${#raw_cur}}"
     fi
+    READLINE_LINE="${line}${COMPREPLY}${READLINE_LINE:$READLINE_POINT}"
+    ((READLINE_POINT += ${#COMPREPLY} - ${#raw_cur}))
+  fi
 
-    printf '\r'
-    command tput el 2>/dev/null || echo -ne "\033[K"
+  printf '\r'
+  command tput el 2>/dev/null || echo -ne "\033[K"
 }
 
 _fzf_bash_completion_selector() {
-    (
+  (
 
-        local fzf="$(__fzfcmd 2>/dev/null || echo fzf)"
-        local default_height="${FZF_TMUX_HEIGHT:-40%}"
-        if [[ -z "$FZF_TMUX_HEIGHT" ]]; then
-            # get the cursor pos
-            printf '\e[6n' >/dev/tty
-            local buf c
-            until [[ "$buf" =~ $'\x1b'\[([0-9]+)\;[0-9]+R ]]; do
-                read -s -n1 c </dev/tty && buf+="$c"
-            done
-            if [[ "$fzf" == fzf ]] && (( LINES - BASH_REMATCH[1] > LINES * 4 / 10 )); then
-                default_height="$(( LINES - BASH_REMATCH[1] ))"
-            fi
-        fi
+    local fzf="$(__fzfcmd 2>/dev/null || echo fzf)"
+    local default_height="${FZF_TMUX_HEIGHT:-40%}"
+    if [[ -z "$FZF_TMUX_HEIGHT" ]]; then
+      # get the cursor pos
+      printf '\e[6n' >/dev/tty
+      local buf c
+      until [[ "$buf" =~ $'\x1b'\[([0-9]+)\;[0-9]+R ]]; do
+        read -s -n1 c </dev/tty && buf+="$c"
+      done
+      if [[ "$fzf" == fzf ]] && ((LINES - BASH_REMATCH[1] > LINES * 4 / 10)); then
+        default_height="$((LINES - BASH_REMATCH[1]))"
+      fi
+    fi
 
-        local lines=() REPLY
-        while (( ${#lines[@]} < 2 )); do
-            if IFS= read -r; then
-                lines+=( "$REPLY" )
-            elif (( ${#lines[@]} == 1 )); then # only one input
-                printf %s\\n "${lines[0]}" && return
-            else # no input
-                return 1
-            fi
-        done
-        < <( (( ${#lines[@]} )) && printf %s\\n "${lines[@]}"; cat) \
-        FZF_DEFAULT_OPTS="--height $default_height --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" \
-            "$fzf" -1 -0 --prompt "${FZF_TAB_COMPLETION_PROMPT:-> }$line" --nth=2 --with-nth=2,3 -d "$_FZF_COMPLETION_SEP" --ansi \
-    ) | cut -d "$_FZF_COMPLETION_SEP" -f1
+    local lines=() REPLY
+    while ((${#lines[@]} < 2)); do
+      if IFS= read -r; then
+        lines+=("$REPLY")
+      elif ((${#lines[@]} == 1)); then # only one input
+        printf %s\\n "${lines[0]}" && return
+      else # no input
+        return 1
+      fi
+    done
+    FZF_DEFAULT_OPTS="--height $default_height --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" < <(
+      ((${#lines[@]})) && printf %s\\n "${lines[@]}"
+      cat
+    ) \
+      "$fzf" -1 -0 --prompt "${FZF_TAB_COMPLETION_PROMPT:-> }$line" --nth=2 --with-nth=2,3 -d "$_FZF_COMPLETION_SEP" --ansi
+  ) | cut -d "$_FZF_COMPLETION_SEP" -f1
 }
 
 _fzf_bash_completion_expand_alias() {
-    if alias "$1" &>/dev/null; then
-        value=( ${BASH_ALIASES[$1]} )
-        if [ -n "${value[*]}" -a "${value[0]}" != "$1" ]; then
-            raw_comp_words=( "${value[@]}" "${raw_comp_words[@]:1}" )
-        fi
+  if alias "$1" &>/dev/null; then
+    value=(${BASH_ALIASES[$1]})
+    if [ -n "${value[*]}" -a "${value[0]}" != "$1" ]; then
+      raw_comp_words=("${value[@]}" "${raw_comp_words[@]:1}")
     fi
+  fi
 }
 
 _fzf_bash_completion_auto_common_prefix() {
-    if [ "$FZF_COMPLETION_AUTO_COMMON_PREFIX" = true ]; then
-        local prefix item items prefix_len prefix_is_full input_len i
-        IFS= read -r prefix && items=("$prefix") || return
-        prefix_len="${#prefix}"
-        prefix_is_full=1 # prefix == item
+  if [ "$FZF_COMPLETION_AUTO_COMMON_PREFIX" = true ]; then
+    local prefix item items prefix_len prefix_is_full input_len i
+    IFS= read -r prefix && items=("$prefix") || return
+    prefix_len="${#prefix}"
+    prefix_is_full=1 # prefix == item
 
-        input_len="$(( ${#1} ))"
+    input_len="$((${#1}))"
 
-        while [ "$prefix_len" != "$input_len" ] && IFS= read -r item && items+=("$item"); do
-            for ((i=$input_len; i<$prefix_len; i++)); do
-                if [[ "${item:i:1}" != "${prefix:i:1}" ]]; then
-                    prefix_len="$i"
-                    unset prefix_is_full
-                    break
-                fi
-            done
-
-            if [ -z "$prefix_is_full" ] && [ -z "${item:i:1}" ]; then
-                prefix_is_full=1
-            fi
-        done
-
-        if [ "$prefix_len" != "$input_len" ]; then
-            if [ "$FZF_COMPLETION_AUTO_COMMON_PREFIX_PART" == true ] || [ "$prefix_is_full" == 1 ]; then
-                [ "${items[1]}" ] && printf 'compl_nospace=1\n'>&"${__evaled}" # no space if not only one
-                printf %s\\n "${prefix:0:prefix_len}"
-                return
-            fi
+    while [ "$prefix_len" != "$input_len" ] && IFS= read -r item && items+=("$item"); do
+      for ((i = $input_len; i < $prefix_len; i++)); do
+        if [[ "${item:i:1}" != "${prefix:i:1}" ]]; then
+          prefix_len="$i"
+          unset prefix_is_full
+          break
         fi
+      done
 
-        printf %s\\n "${items[@]}"
+      if [ -z "$prefix_is_full" ] && [ -z "${item:i:1}" ]; then
+        prefix_is_full=1
+      fi
+    done
+
+    if [ "$prefix_len" != "$input_len" ]; then
+      if [ "$FZF_COMPLETION_AUTO_COMMON_PREFIX_PART" == true ] || [ "$prefix_is_full" == 1 ]; then
+        [ "${items[1]}" ] && printf 'compl_nospace=1\n' >&"${__evaled}" # no space if not only one
+        printf %s\\n "${prefix:0:prefix_len}"
+        return
+      fi
     fi
 
-    cat
+    printf %s\\n "${items[@]}"
+  fi
+
+  cat
 }
 
 fzf_bash_completer() {
-    local value code
-    local compl_bashdefault compl_default compl_dirnames compl_filenames compl_noquote compl_nosort compl_nospace compl_plusdirs
+  local value code
+  local compl_bashdefault compl_default compl_dirnames compl_filenames compl_noquote compl_nosort compl_nospace compl_plusdirs
 
-    # preload completions in top shell
-    { complete -p -- "$1" || __load_completion "$1"; } &>/dev/null
-    local compspec
-    if ! compspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
-        return
-    fi
+  # preload completions in top shell
+  { complete -p -- "$1" || __load_completion "$1"; } &>/dev/null
+  local compspec
+  if ! compspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
+    return
+  fi
 
-    eval "$(
+  eval "$(
     local _fzf_sentinel1=b5a0da60-3378-4afd-ba00-bc1c269bef68
     local _fzf_sentinel2=257539ae-7100-4cd8-b822-a1ef35335e88
     (
-        set -o pipefail
+      set -o pipefail
 
-        # hack: hijack compopt
-        compopt() { _fzf_bash_completion_compopt "$@"; }
+      # hack: hijack compopt
+      compopt() { _fzf_bash_completion_compopt "$@"; }
 
-        exec {__evaled}>&1
-        coproc (
-            (
-                # input from tty in case one of the completions wants fzf using $FZF_DEFAULT_COMMAND
-                exec </dev/tty
+      exec {__evaled}>&1
+      coproc (
+        (
+          # input from tty in case one of the completions wants fzf using $FZF_DEFAULT_COMMAND
+          exec </dev/tty
 
-                count=0
-                _fzf_bash_completion_complete "$@"
-                while (( $? == 124 )); do
-                    (( count ++ ))
-                    if (( count > 32 )); then
-                        echo "$1: possible retry loop" >/dev/tty
-                        break
-                    fi
-                    _fzf_bash_completion_complete "$@"
-                done
-                printf '%s\n' "$_FZF_COMPLETION_SEP$_fzf_sentinel1$_fzf_sentinel2"
-            ) | $_fzf_bash_completion_sed -un "/$_fzf_sentinel1$_fzf_sentinel2/q; p" \
-              | _fzf_bash_completion_auto_common_prefix "$raw_cur" \
-              | _fzf_bash_completion_unbuffered_awk '$0!="" && !x[$0]++' '$0 = $0 sep "\x1b[37m" substr($0, 1, len) "\x1b[0m" sep substr($0, len+1)' -vlen="${#raw_cur}" -vsep="$_FZF_COMPLETION_SEP"
-        )
-        local coproc_pid="$COPROC_PID"
-        value="$(_fzf_bash_completion_selector "$1" "$raw_cur" "$3" <&"${COPROC[0]}")"
-        code="$?"
-        value="$(<<<"$value" tr \\n \ )"
-        value="${value% }"
+          count=0
+          _fzf_bash_completion_complete "$@"
+          while (($? == 124)); do
+            ((count++))
+            if ((count > 32)); then
+              echo "$1: possible retry loop" >/dev/tty
+              break
+            fi
+            _fzf_bash_completion_complete "$@"
+          done
+          printf '%s\n' "$_FZF_COMPLETION_SEP$_fzf_sentinel1$_fzf_sentinel2"
+        ) | $_fzf_bash_completion_sed -un "/$_fzf_sentinel1$_fzf_sentinel2/q; p" |
+          _fzf_bash_completion_auto_common_prefix "$raw_cur" |
+          _fzf_bash_completion_unbuffered_awk '$0!="" && !x[$0]++' '$0 = $0 sep "\x1b[37m" substr($0, 1, len) "\x1b[0m" sep substr($0, len+1)' -vlen="${#raw_cur}" -vsep="$_FZF_COMPLETION_SEP"
+      )
+      local coproc_pid="$COPROC_PID"
+      value="$(_fzf_bash_completion_selector "$1" "$raw_cur" "$3" <&"${COPROC[0]}")"
+      code="$?"
+      value="$(<<<"$value" tr \\n \ )"
+      value="${value% }"
 
-        printf 'COMPREPLY=%q\n' "$value"
-        printf 'code=%q\n' "$code"
+      printf 'COMPREPLY=%q\n' "$value"
+      printf 'code=%q\n' "$code"
 
-        # kill descendant processes of coproc
-        descend_process () {
-            printf '%s\n' "$1"
-            for pid in $(ps -ef | "$_fzf_bash_completion_awk" -v ppid="$1" '$3 == ppid { print $2 }'); do
-                descend_process "$pid"
-            done
-        }
-        kill -- $(descend_process "$coproc_pid") 2>/dev/null
+      # kill descendant processes of coproc
+      descend_process() {
+        printf '%s\n' "$1"
+        for pid in $(ps -ef | "$_fzf_bash_completion_awk" -v ppid="$1" '$3 == ppid { print $2 }'); do
+          descend_process "$pid"
+        done
+      }
+      kill -- $(descend_process "$coproc_pid") 2>/dev/null
 
-        printf '%s\n' ": $_fzf_sentinel1$_fzf_sentinel2"
+      printf '%s\n' ": $_fzf_sentinel1$_fzf_sentinel2"
     ) | $_fzf_bash_completion_sed -un "/$_fzf_sentinel1$_fzf_sentinel2/q; p"
-    )" 2>/dev/null
+  )" 2>/dev/null
 
-    if [ "$code" = 0 ]; then
-        COMPREPLY="${COMPREPLY[*]}"
-        [ "$compl_nospace" != 1 ] && COMPREPLY="$COMPREPLY "
-        [[ "$compl_filenames" == *1* ]] && COMPREPLY="${COMPREPLY/%\/ //}"
-    fi
+  if [ "$code" = 0 ]; then
+    COMPREPLY="${COMPREPLY[*]}"
+    [ "$compl_nospace" != 1 ] && COMPREPLY="$COMPREPLY "
+    [[ "$compl_filenames" == *1* ]] && COMPREPLY="${COMPREPLY/%\/ //}"
+  fi
 }
 
 _fzf_bash_completion_complete() {
-    local compgen_actions=() compspec=
-    if ! compspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
+  local compgen_actions=() compspec=
+  if ! compspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
+    return
+  fi
+
+  local args=("$@")
+  eval "compspec=( $compspec )"
+  set -- "${compspec[@]}"
+  shift # remove the complete command
+  while (($# > 1)); do
+    case "$1" in
+    -F)
+      local compl_function="$2"
+      shift
+      ;;
+    -C)
+      local compl_command="$2"
+      shift
+      ;;
+    -G)
+      local compl_globpat="$2"
+      shift
+      ;;
+    -W)
+      local compl_wordlist="$2"
+      shift
+      ;;
+    -X)
+      local compl_xfilter="$2"
+      shift
+      ;;
+    -o)
+      _fzf_bash_completion_compopt -o "$2"
+      shift
+      ;;
+    -A)
+      local compgen_opts+=("$1" "$2")
+      shift
+      ;;
+    -P)
+      local compl_prefix="$(_fzf_bash_completion_awk_escape "$2")"
+      shift
+      ;;
+    -S)
+      local compl_suffix="$(_fzf_bash_completion_awk_escape "$2")"
+      shift
+      ;;
+    -[a-z])
+      compgen_actions+=("$1")
+      ;;
+    esac
+    shift
+  done
+  set -- "${args[@]}"
+
+  COMPREPLY=()
+  if [ -n "$compl_function" ]; then
+    "$compl_function" "$@" >/dev/null
+    if [ "$?" = 124 ]; then
+      local newcompspec
+      if ! newcompspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
         return
+      elif [ "$newcompspec" != "$compspec" ]; then
+        return 124
+      fi
+      "$compl_function" "$@" >/dev/null
     fi
+  fi
 
-    local args=( "$@" )
-    eval "compspec=( $compspec )"
-    set -- "${compspec[@]}"
-    shift # remove the complete command
-    while (( $# > 1 )); do
-        case "$1" in
-        -F)
-            local compl_function="$2"
-            shift ;;
-        -C)
-            local compl_command="$2"
-            shift ;;
-        -G)
-            local compl_globpat="$2"
-            shift ;;
-        -W)
-            local compl_wordlist="$2"
-            shift ;;
-        -X)
-            local compl_xfilter="$2"
-            shift ;;
-        -o)
-            _fzf_bash_completion_compopt -o "$2"
-            shift ;;
-        -A)
-            local compgen_opts+=( "$1" "$2" )
-            shift ;;
-        -P)
-            local compl_prefix="$(_fzf_bash_completion_awk_escape "$2")"
-            shift ;;
-        -S)
-            local compl_suffix="$(_fzf_bash_completion_awk_escape "$2")"
-            shift ;;
-        -[a-z])
-            compgen_actions+=( "$1" )
-            ;;
-        esac
-        shift
-    done
-    set -- "${args[@]}"
+  if [[ "$compl_filenames" == 1 ]]; then
+    local dir_marker=_fzf_bash_completion_dir_marker
+  else
+    local dir_marker=cat
+  fi
 
-    COMPREPLY=()
-    if [ -n "$compl_function" ]; then
-        "$compl_function" "$@" >/dev/null
-        if [ "$?" = 124 ]; then
-            local newcompspec
-            if ! newcompspec="$(_fzf_bash_completion_compspec "$@" 2>/dev/null)"; then
-                return
-            elif [ "$newcompspec" != "$compspec" ]; then
-                return 124
-            fi
-            "$compl_function" "$@" >/dev/null
-        fi
-    fi
+  printf 'compl_filenames=%q\n' "$compl_filenames" >&"${__evaled}"
+  printf 'compl_noquote=%q\n' "$compl_noquote" >&"${__evaled}"
+  printf 'compl_nospace=%q\n' "$compl_nospace" >&"${__evaled}"
 
-    if [[ "$compl_filenames" == 1 ]]; then
-        local dir_marker=_fzf_bash_completion_dir_marker
-    else
-        local dir_marker=cat
-    fi
-
-    printf 'compl_filenames=%q\n' "$compl_filenames" >&"${__evaled}"
-    printf 'compl_noquote=%q\n' "$compl_noquote" >&"${__evaled}"
-    printf 'compl_nospace=%q\n' "$compl_nospace" >&"${__evaled}"
-
+  (
     (
+      if [ -n "${compgen_actions[*]}" ]; then
+        compgen "${compgen_actions[@]}" -- "$2"
+      fi
+
+      if [ -n "$compl_globpat" ]; then
+        printf %s\\n "$compl_globpat"
+      fi
+
+      if [ -n "$compl_wordlist" ]; then
+        eval "printf '%s\\n' $compl_wordlist"
+      fi
+
+      if [ -n "${COMPREPLY[*]}" ]; then
+        printf %s\\n "${COMPREPLY[@]}"
+      fi
+
+      if [ -n "$compl_command" ]; then
         (
-            if [ -n "${compgen_actions[*]}" ]; then
-                compgen "${compgen_actions[@]}" -- "$2"
-            fi
+          unset COMP_WORDS COMP_CWORD
+          export COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" COMP_KEY="$COMP_KEY" COMP_TYPE="$COMP_TYPE"
+          eval "$compl_command"
+        )
+      fi
 
-            if [ -n "$compl_globpat" ]; then
-                printf %s\\n "$compl_globpat"
-            fi
-
-            if [ -n "$compl_wordlist" ]; then
-                eval "printf '%s\\n' $compl_wordlist"
-            fi
-
-            if [ -n "${COMPREPLY[*]}" ]; then
-                printf %s\\n "${COMPREPLY[@]}"
-            fi
-
-            if [ -n "$compl_command" ]; then
-                (
-                    unset COMP_WORDS COMP_CWORD
-                    export COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" COMP_KEY="$COMP_KEY" COMP_TYPE="$COMP_TYPE"
-                    eval "$compl_command"
-                )
-            fi
-
-            printf '\n'
-        ) | _fzf_bash_completion_apply_xfilter "$compl_xfilter" \
-          | _fzf_bash_completion_unbuffered_awk '$0!=""' 'sub(find, replace)' -vfind='.*' -vreplace="$(printf %s "$compl_prefix" | "$_fzf_bash_completion_sed" 's/[&\]/\\&/g')&$(printf %s "$compl_suffix" | "$_fzf_bash_completion_sed" 's/[&\]/\\&/g')" \
-          | if IFS= read -r line || (( ${#COMPREPLY[@]} )); then
-              ([[ -z "$line" ]] || printf '%s\n' "$line"; cat) | _fzf_bash_completion_quote_filenames "$@"
-            else
-                # got no results
-                local compgen_opts=()
-                [ "$compl_bashdefault" = 1 ] && compgen_opts+=( -o bashdefault )
-                [ "$compl_default" = 1 ] && compgen_opts+=( -o default )
-                [ "$compl_dirnames" = 1 ] && compgen_opts+=( -o dirnames )
-                # don't double invoke fzf
-                if [ -n "${compgen_opts[*]}" ]; then
-                    # these are all filenames
-                    printf 'compl_filenames=1\n'>&"${__evaled}"
-                    compgen "${compgen_opts[@]}" -- "$2" \
-                    | compl_filenames=1 _fzf_bash_completion_quote_filenames "$@" \
-                    | _fzf_bash_completion_dir_marker
-                fi
-            fi
-
-        if [ "$compl_plusdirs" = 1 ]; then
-            compgen -o dirnames -- "$2" \
-            | compl_filenames=1 _fzf_bash_completion_quote_filenames "$@" \
-            | _fzf_bash_completion_dir_marker
+      printf '\n'
+    ) | _fzf_bash_completion_apply_xfilter "$compl_xfilter" |
+      _fzf_bash_completion_unbuffered_awk '$0!=""' 'sub(find, replace)' -vfind='.*' -vreplace="$(printf %s "$compl_prefix" | "$_fzf_bash_completion_sed" 's/[&\]/\\&/g')&$(printf %s "$compl_suffix" | "$_fzf_bash_completion_sed" 's/[&\]/\\&/g')" |
+      if IFS= read -r line || ((${#COMPREPLY[@]})); then
+        (
+          [[ -z "$line" ]] || printf '%s\n' "$line"
+          cat
+        ) | _fzf_bash_completion_quote_filenames "$@"
+      else
+        # got no results
+        local compgen_opts=()
+        [ "$compl_bashdefault" = 1 ] && compgen_opts+=(-o bashdefault)
+        [ "$compl_default" = 1 ] && compgen_opts+=(-o default)
+        [ "$compl_dirnames" = 1 ] && compgen_opts+=(-o dirnames)
+        # don't double invoke fzf
+        if [ -n "${compgen_opts[*]}" ]; then
+          # these are all filenames
+          printf 'compl_filenames=1\n' >&"${__evaled}"
+          compgen "${compgen_opts[@]}" -- "$2" |
+            compl_filenames=1 _fzf_bash_completion_quote_filenames "$@" |
+            _fzf_bash_completion_dir_marker
         fi
-    ) \
-    | "$dir_marker"
+      fi
+
+    if [ "$compl_plusdirs" = 1 ]; then
+      compgen -o dirnames -- "$2" |
+        compl_filenames=1 _fzf_bash_completion_quote_filenames "$@" |
+        _fzf_bash_completion_dir_marker
+    fi
+  ) |
+    "$dir_marker"
 }
 
 _fzf_bash_completion_apply_xfilter() {
-    if [ -z "$1" ]; then
-        cat
-        return
-    fi
+  if [ -z "$1" ]; then
+    cat
+    return
+  fi
 
-    local pattern line word="$cur"
-    word="${word//\//\\/}"
-    word="${word//&/\\&}"
-    # replace any unescaped & with the word being completed
-    pattern="$("$_fzf_bash_completion_sed" 's/\(\(^\|[^\]\)\(\\\\\)*\)&/\1'"$word"'/g' <<<"${1:1}")"
+  local pattern line word="$cur"
+  word="${word//\//\\/}"
+  word="${word//&/\\&}"
+  # replace any unescaped & with the word being completed
+  pattern="$("$_fzf_bash_completion_sed" 's/\(\(^\|[^\]\)\(\\\\\)*\)&/\1'"$word"'/g' <<<"${1:1}")"
 
-    if [ "${1::1}" = ! ]; then
-        while IFS= read -r line; do [[ "$line" == $pattern ]] && printf '%s\n' "$line"; done
-    elif [ -n "$1" ]; then
-        while IFS= read -r line; do [[ "$line" != $pattern ]] && printf '%s\n' "$line"; done
-    fi
+  if [ "${1::1}" = ! ]; then
+    while IFS= read -r line; do [[ "$line" == $pattern ]] && printf '%s\n' "$line"; done
+  elif [ -n "$1" ]; then
+    while IFS= read -r line; do [[ "$line" != $pattern ]] && printf '%s\n' "$line"; done
+  fi
 }
 
 _fzf_bash_completion_dir_marker() {
-    local line expanded
-    while IFS= read -r line; do
-        expanded="$line"
+  local line expanded
+  while IFS= read -r line; do
+    expanded="$line"
 
-        # adapted from __expand_tilde_by_ref
-        if [[ "$expanded" == \~* ]]; then
-            eval "$(printf expanded=~%q "${expanded:1}")"
-        fi
+    # adapted from __expand_tilde_by_ref
+    if [[ "$expanded" == \~* ]]; then
+      eval "$(printf expanded=~%q "${expanded:1}")"
+    fi
 
-        if [[ "$compl_noquote" != 1 && "$expanded" == *\\* ]]; then
-            expanded="$("$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"$expanded")"
-        fi
+    if [[ "$compl_noquote" != 1 && "$expanded" == *\\* ]]; then
+      expanded="$("$_fzf_bash_completion_sed" -r 's/\\(.)/\1/g' <<<"$expanded")"
+    fi
 
-        [ -d "$expanded" ] && line="${line%/}/"
-        printf '%s\n' "$line"
-    done
+    [ -d "$expanded" ] && line="${line%/}/"
+    printf '%s\n' "$line"
+  done
 }
 
 _fzf_bash_completion_quote_filenames() {
-    if [ "$compl_noquote" != 1 -a "$compl_filenames" = 1 ]; then
-        local IFS line
-        while IFS= read -r line; do
-            if [ "${line::1}" = '~' ]; then
-                printf '~%q\n' "${line:1}"
-            else
-                printf '%q\n' "$line"
-            fi
-        done
-    else
-        cat
-    fi
+  if [ "$compl_noquote" != 1 -a "$compl_filenames" = 1 ]; then
+    local IFS line
+    while IFS= read -r line; do
+      if [ "${line::1}" = '~' ]; then
+        printf '~%q\n' "${line:1}"
+      else
+        printf '%q\n' "$line"
+      fi
+    done
+  else
+    cat
+  fi
 }
 
 _fzf_bash_completion_compopt() {
-    while [ "$#" -gt 0 ]; do
-        local val
-        if [ "$1" = -o ]; then
-            val=1
-        elif [ "$1" = +o ]; then
-            val=0
-        else
-            break
-        fi
+  while [ "$#" -gt 0 ]; do
+    local val
+    if [ "$1" = -o ]; then
+      val=1
+    elif [ "$1" = +o ]; then
+      val=0
+    else
+      break
+    fi
 
-        if [[ "$2" =~ bashdefault|default|dirnames|filenames|noquote|nosort|nospace|plusdirs ]]; then
-            eval "compl_$2=$val"
-        fi
-        shift 2
-    done
+    if [[ "$2" =~ bashdefault|default|dirnames|filenames|noquote|nosort|nospace|plusdirs ]]; then
+      eval "compl_$2=$val"
+    fi
+    shift 2
+  done
 }

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -291,8 +291,14 @@ fzf_bash_completion() {
 
 _fzf_bash_completion_selector() {
   (
+    local fzf
+    # modern fzf includes a --tmux option. if $FZF_COMPLETION_TMUX_LEGACY is false, use that
+    if [[ "${FZF_COMPLETION_TMUX_LEGACY:-true}" == "true" ]]; then
+      fzf="$(__fzfcmd 2>/dev/null || echo fzf)"
+    else
+      fzf="$(command -v fzf)"
+    fi
 
-    local fzf="$(__fzfcmd 2>/dev/null || echo fzf)"
     local default_height="${FZF_TMUX_HEIGHT:-40%}"
     if [[ -z "$FZF_TMUX_HEIGHT" ]]; then
       # get the cursor pos


### PR DESCRIPTION
This update introduces the `$FZF_COMPLETION_TMUX_LEGACY` environment variable, giving users the flexibility to switch between the legacy `fzf-tmux` wrapper and the modern `fzf --tmux` integration. By default, `$FZF_COMPLETION_TMUX_LEGACY` is set to `true`, preserving the current behavior. When set to `false`, it leverages native `fzf --tmux`, fixing command interpretation issues like:  

```
bash: fzf-tmux --height=40% -- : command not found
```  

The README has been updated with instructions for using the new environment variable and includes a tip on enabling fzf’s tmux mode (`export FZF_TMUX=1`) for smoother completion experiences, as suggested in the [fzf README](https://github.com/junegunn/fzf?tab=readme-ov-file#--tmux-mode).  

## Key Changes:  
- Enhanced `fzf_bash_completion_selector` to switch between legacy and native tmux handling based on `$FZF_COMPLETION_TMUX_LEGACY`.  
- Updated the README to include the new variable and a tip for enabling tmux mode with fzf.  

## Why This Change:  
This fixes known issues with legacy `fzf-tmux` command interpretation while allowing users to switch to the more robust native `fzf --tmux` integration for enhanced reliability.  

## Testing:  
- Verified both legacy and native tmux modes work as expected in bash with and without tmux.  
- Confirmed proper fallback behavior in case of missing configurations.
