### PR TITLE
fix(bash/fzf): fix the command with flags

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -317,7 +317,7 @@ _fzf_bash_completion_selector() {
         done
         < <( (( ${#lines[@]} )) && printf %s\\n "${lines[@]}"; cat) \
         FZF_DEFAULT_OPTS="--height $default_height --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" \
-            "$fzf" -1 -0 --prompt "${FZF_TAB_COMPLETION_PROMPT:-> }$line" --nth=2 --with-nth=2,3 -d "$_FZF_COMPLETION_SEP" --ansi \
+            $fzf -1 -0 --prompt "${FZF_TAB_COMPLETION_PROMPT:-> }$line" --nth=2 --with-nth=2,3 -d "$_FZF_COMPLETION_SEP" --ansi \
     ) | cut -d "$_FZF_COMPLETION_SEP" -f1
 }
 


### PR DESCRIPTION
In presence of , the variable `fzf`  is expanded into e.g. `fzf-tmux -p 90%,85% -- ` (the output of `__fzfcmd`), which in turn, if double quotes are used, results in bash understanding it as a _whole command (see bash expansion rules)_, so the  error like 'fzf-tmux -p 90%,85% -- : command not found' is thrown.

