### PR TITLE
fix: Stop automatically expanding aliases before bash completion.

### DIFF
--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -239,7 +239,7 @@ fzf_bash_completion() {
 
     if [[ ${#raw_comp_words[@]} -gt 1 ]] \
       && shopt -q progcomp_alias \
-      && ! complete -p "${raw_comp_words[0]}" >/dev/null; then
+      && ! complete -p "${raw_comp_words[0]}" &>/dev/null; then
         _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
     fi
     readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -237,8 +237,10 @@ fzf_bash_completion() {
         readarray -t raw_comp_words < <(_fzf_bash_completion_parse_line <<<"$line")
     fi
 
-    if [[ ${#raw_comp_words[@]} -gt 1 ]]; then
-        _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
+    if [[ ${#raw_comp_words[@]} -gt 1 ]] && shopt -q progcomp_alias; then
+        if ! complete -p "${raw_comp_words[0]}" >/dev/null; then
+            _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
+        fi
     fi
     readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)
 

--- a/bash/fzf-bash-completion.sh
+++ b/bash/fzf-bash-completion.sh
@@ -237,10 +237,10 @@ fzf_bash_completion() {
         readarray -t raw_comp_words < <(_fzf_bash_completion_parse_line <<<"$line")
     fi
 
-    if [[ ${#raw_comp_words[@]} -gt 1 ]] && shopt -q progcomp_alias; then
-        if ! complete -p "${raw_comp_words[0]}" >/dev/null; then
-            _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
-        fi
+    if [[ ${#raw_comp_words[@]} -gt 1 ]] \
+      && shopt -q progcomp_alias \
+      && ! complete -p "${raw_comp_words[0]}" >/dev/null; then
+        _fzf_bash_completion_expand_alias "${raw_comp_words[@]}"
     fi
     readarray -t COMP_WORDS < <(printf '%s\n' "${raw_comp_words[@]}" | _fzf_bash_completion_unquote_strings)
 


### PR DESCRIPTION
By default, Bash doesn't do that. In Bash5+ there's a shopt that controls this behavior: `progcomp_alias`.

> If set, and programmable completion is enabled, Bash treats a command
> name that doesn’t have any completions as a possible alias and
> attempts alias expansion. If it has an alias, Bash attempts
> programmable completion using the command word resulting from the
> expanded alias.

The other main delta here is that Bash only performs the alias expansion if the command doesn't already have a compspec defined for it, so I've added that behavior here, too.